### PR TITLE
Add support for >= Ruby 2.0.0-p195

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -20,6 +20,7 @@ Dir.chdir 'sparsehash-1.8.1' do
 end
 
 $CFLAGS += " -I./local_installed/include "
+$CPPFLAGS += " -I./local_installed/include "
 
 if RUBY_VERSION < '1.9'
   # appears to link using gcc on 1.8 [mingw at least]


### PR DESCRIPTION
For some reason Ruby 2.0 versions with a patchlevel > 0 have trouble building google_hash.
It looks like something called CCDLFLAGS was introduced and CFLAGS stopped being added to the CXXFLAGS.

Commit in ruby: https://github.com/ruby/ruby/commit/2e26edb633606f1e99d22817678e11c25f7d2882
